### PR TITLE
Fixed typo in link

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ server.render jobs
 ```
 
 ## Setup
-Due to kinks (see [Known problems](https://github.com/FelixAkk/nota#known-
-problems)) in the depencencies that are still being worked out, Nota is a bit
+Due to kinks (see [Known problems](https://github.com/FelixAkk/nota#known-problems))
+in the depencencies that are still being worked out, Nota is a bit
 picky on it's environment and dependencies. We recommend running Nota under
 Linux, and we've made a provisioning script that sets up all dependencies for
 Linux (and unverified support for Mac and Windows under cywin).


### PR DESCRIPTION
Links should not be split over multiple lines in MD
